### PR TITLE
changed to setuptools and replaced cStringIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 pypcd.egg-info
 build
+dist

--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -10,7 +10,7 @@ TODO better support for rgb nonsense
 import re
 import struct
 import copy
-import cStringIO as sio
+from io import StringIO as sio
 import numpy as np
 import warnings
 import lzf

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup
+from setuptools import setup
 
 # Get version and release info, which is all stored in pypcd/version.py
 ver_file = os.path.join('pypcd', 'version.py')


### PR DESCRIPTION
Small changes to adapt to Python 3. Changed to setuptools (as also seen in another open PR).