### PR TITLE
Fix for python3 compatibility

### DIFF
--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -12,7 +12,7 @@ dimatura@cmu.edu, 2013-2018
 import re
 import struct
 import copy
-import cStringIO as sio
+from io import StringIO as sio
 import numpy as np
 import warnings
 import lzf


### PR DESCRIPTION
Quick fix for importing StringIO module import as described here:
[http://python-future.org/compatible_idioms.html#stringio](http://python-future.org/compatible_idioms.html#stringio)