### PR TITLE
cStringIO package has been deprecated, and it was replaced with io.By…

### DIFF
--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -12,7 +12,7 @@ dimatura@cmu.edu, 2013-2018
 import re
 import struct
 import copy
-import cStringIO as sio
+from io import BytesIO as sio
 import numpy as np
 import warnings
 import lzf


### PR DESCRIPTION
`import cStringIO as sio`

the import script above gives me the following error

`ModuleNotFoundError: No module named 'cStringIO'`

So I tried to install the package:

`pip install cStringIO`  

I got the response below:

`ERROR: Could not find a version that satisfies the requirement cStringIO (from versions: none)
ERROR: No matching distribution found for cStringIO`

The import below solved my problem, so I replaced this with the previous import.

`from io import BytesIO as sio`