### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.rst


### PR DESCRIPTION
Include missing files in sdist for #32

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.ktIT3L1wat
+ trap 'rm -rf /tmp/tmp.ktIT3L1wat' EXIT
+ python -m venv /tmp/tmp.ktIT3L1wat
+ python setup.py sdist -d /tmp/tmp.ktIT3L1wat
running sdist
running egg_info
writing pypcd.egg-info/PKG-INFO
writing dependency_links to pypcd.egg-info/dependency_links.txt
writing requirements to pypcd.egg-info/requires.txt
writing top-level names to pypcd.egg-info/top_level.txt
reading manifest file 'pypcd.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pypcd.egg-info/SOURCES.txt'
running check
creating pypcd-0.1.1
creating pypcd-0.1.1/pypcd
creating pypcd-0.1.1/pypcd.egg-info
copying files to pypcd-0.1.1...
copying HISTORY.rst -> pypcd-0.1.1
copying MANIFEST.in -> pypcd-0.1.1
copying README.rst -> pypcd-0.1.1
copying setup.cfg -> pypcd-0.1.1
copying setup.py -> pypcd-0.1.1
copying pypcd/__init__.py -> pypcd-0.1.1/pypcd
copying pypcd/nea_pc_format.py -> pypcd-0.1.1/pypcd
copying pypcd/numpy_pc2.py -> pypcd-0.1.1/pypcd
copying pypcd/pdutil.py -> pypcd-0.1.1/pypcd
copying pypcd/pypcd.py -> pypcd-0.1.1/pypcd
copying pypcd/sautil.py -> pypcd-0.1.1/pypcd
copying pypcd.egg-info/PKG-INFO -> pypcd-0.1.1/pypcd.egg-info
copying pypcd.egg-info/SOURCES.txt -> pypcd-0.1.1/pypcd.egg-info
copying pypcd.egg-info/dependency_links.txt -> pypcd-0.1.1/pypcd.egg-info
copying pypcd.egg-info/not-zip-safe -> pypcd-0.1.1/pypcd.egg-info
copying pypcd.egg-info/requires.txt -> pypcd-0.1.1/pypcd.egg-info
copying pypcd.egg-info/top_level.txt -> pypcd-0.1.1/pypcd.egg-info
Writing pypcd-0.1.1/setup.cfg
Creating tar archive
removing 'pypcd-0.1.1' (and everything under it)
+ cd /
+ /tmp/tmp.ktIT3L1wat/bin/pip install /tmp/tmp.ktIT3L1wat/pypcd-0.1.1.tar.gz
Processing /tmp/tmp.ktIT3L1wat/pypcd-0.1.1.tar.gz
Collecting numpy (from pypcd==0.1.1)
  Using cached https://files.pythonhosted.org/packages/cf/5d/e8198f11dd73a91f7bde15ca88a2b78913fa2b416ae2dc2a6aeafcf4c63d/numpy-1.18.4-cp38-cp38-manylinux1_x86_64.whl
Collecting python-lzf (from pypcd==0.1.1)
  Downloading https://files.pythonhosted.org/packages/e3/33/b8f67bbe695ccc39f868ae55378993a7bde1357a0567803a80467c8ce1a4/python-lzf-0.2.4.tar.gz
Installing collected packages: numpy, python-lzf, pypcd
  Running setup.py install for python-lzf: started
    Running setup.py install for python-lzf: finished with status 'done'
  Running setup.py install for pypcd: started
    Running setup.py install for pypcd: finished with status 'done'
Successfully installed numpy-1.18.4 pypcd-0.1.1 python-lzf-0.2.4
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.ktIT3L1wat
```
