### PR TITLE
Update the import of the StringIO library to Python 3.x

### DIFF
--- a/pypcd/pypcd.py
+++ b/pypcd/pypcd.py
@@ -12,7 +12,7 @@ dimatura@cmu.edu, 2013-2018
 import re
 import struct
 import copy
-import cStringIO as sio
+from io import StringIO as sio
 import numpy as np
 import warnings
 import lzf


### PR DESCRIPTION
# Summary
This pull request resolves a module import error in the pypcd library:

`ModuleNotFoundError: No module named 'cStringIO'`

# Changes
Replaced the use of cStringIO with io.StringIO to ensure compatibility with Python 3.x.

# Impact
Allows the pypcd library to function correctly with Python 3.x.

# Testing
Verified that the library imports successfully and functions as expected in a Python 3.x environment.